### PR TITLE
Add links to viewer for selected play

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,14 @@
             <div class="checkbox-group">
             <a id="suggestor-link" href="suggestor.html" class="button">Rollenvorschläge für die Probe</a>
             </div>
+
+            <!-- Links to Viewer Pages -->
+            <div class="checkbox-group">
+              <a id="viewer-link" href="viewer.html" class="button">Bühnen-Viewer öffnen</a>
+            </div>
+            <div class="checkbox-group">
+              <a id="viewer2-link" href="viewer2.html" class="button">Schauspieler-Viewer öffnen</a>
+            </div>
           </div>
 
           <!-- Collapsible Director -->

--- a/script.js
+++ b/script.js
@@ -741,6 +741,20 @@ async function init() {
     sugg.setAttribute('href', u.pathname + u.search)
   }
 
+  // Update viewer links to carry play param
+  const viewer = document.getElementById('viewer-link')
+  if (viewer) {
+    const u = new URL(viewer.getAttribute('href'), window.location.href)
+    u.searchParams.set('play', playId)
+    viewer.setAttribute('href', u.pathname + u.search)
+  }
+  const viewer2 = document.getElementById('viewer2-link')
+  if (viewer2) {
+    const u2 = new URL(viewer2.getAttribute('href'), window.location.href)
+    u2.searchParams.set('play', playId)
+    viewer2.setAttribute('href', u2.pathname + u2.search)
+  }
+
   let data = await loadScript()
   window.scriptData = data
   window.actors = getActors(data)


### PR DESCRIPTION
Add links to open the viewer pages (`viewer.html` and `viewer2.html`) with the currently selected play to improve user workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-c91edd7e-5f83-4061-9b59-38500d537e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c91edd7e-5f83-4061-9b59-38500d537e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

